### PR TITLE
Load font-awesome.min.css via layout xml

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <referenceContainer name="header.container">
-        <block class="Trustpilot\Reviews\Block\Head" name="trustpilot.header.head" as="trustpilot.header.head" template="Trustpilot_Reviews::header/head.phtml"/>
-    </referenceContainer>
     <head>
         <css src="Trustpilot_Reviews::css/trustpilot.css"/>
+        <css src="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" src_type="url" />
     </head>
+    <body>
+        <referenceContainer name="header.container">
+            <block class="Trustpilot\Reviews\Block\Head" name="trustpilot.header.head" as="trustpilot.header.head"
+                   template="Trustpilot_Reviews::header/head.phtml"/>
+        </referenceContainer>
+    </body>
 </page>

--- a/view/frontend/web/css/trustpilot.css
+++ b/view/frontend/web/css/trustpilot.css
@@ -1,5 +1,3 @@
-@import url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
-
 .shake-and-hide-element {
     -moz-animation: hide-element 0s ease-in 5s forwards, shake-element  1s;
     /* Firefox */


### PR DESCRIPTION
I suggest that we remove the `@import` url from `view/frontend/web/css/trustpilot.css` and load the external CSS file via the layout XML instead. This is a more cleaner approach, plus it gives developers the possibility to remove `font-awesome.min.css` via a another module.

Also, I noticed that:
```
      <referenceContainer name="header.container">
            <block class="Trustpilot\Reviews\Block\Head" name="trustpilot.header.head" as="trustpilot.header.head"
                   template="Trustpilot_Reviews::header/head.phtml"/>
        </referenceContainer>
```
Should be in a `<body>` tag.
