### PR TITLE
Moved @import css to default.xml

### DIFF
--- a/view/adminhtml/layout/default.xml
+++ b/view/adminhtml/layout/default.xml
@@ -6,6 +6,7 @@
         <script src="Trustpilot_Reviews::js/bowser.min.js"/>
         <script src="Trustpilot_Reviews::js/validation.js"/>
         <script src="Trustpilot_Reviews::js/elements.js"/>
+        <css    src="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" src_type="url"/>
         <css    src="Trustpilot_Reviews::css/trustpilot.css"/>
     </head>
 </page>

--- a/view/adminhtml/web/css/trustpilot-message.css
+++ b/view/adminhtml/web/css/trustpilot-message.css
@@ -1,5 +1,3 @@
-@import url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
-
 .shake-and-hide-element {
     -moz-animation: hide-element 0s ease-in 10s forwards, shake-element  1s;
     /* Firefox */

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -4,6 +4,7 @@
         <block class="Trustpilot\Reviews\Block\Head" name="trustpilot.head.head" as="trustpilot.head.head" template="Trustpilot_Reviews::head/head.phtml"/>
     </referenceContainer>
     <head>
+        <css    src="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" src_type="url"/>
         <css src="Trustpilot_Reviews::css/trustpilot.css"/>
     </head>
 </page>

--- a/view/frontend/web/css/trustpilot.css
+++ b/view/frontend/web/css/trustpilot.css
@@ -1,5 +1,3 @@
-@import url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
-
 .shake-and-hide-element {
     -moz-animation: hide-element 0s ease-in 5s forwards, shake-element  1s;
     /* Firefox */


### PR DESCRIPTION
When deploying static content in Magento with the strategy Compact, the code fails on the `@import` of the font-awesome.

Example cli command `bin/magento setup:static-content:deploy --strategy=compact --area frontend  nl_NL --no-interaction -f` 
Error: 
``` 
Deploy using compact strategy
base/Magento/base/default               1610/1610           ============================ 100% %  5 secs
frontend/Magento/base/default           665/832             ======================>----- 79% %   2 secs


  [Magento\Framework\Exception\FileSystemException]
  Cannot read contents from file "/data/web/projects/my-wbshop/deploy/development/releases/4/pub/static/frontend/Magento/base/default/css/https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" Warning!file_get_contents(/data/w
  eb/projectsmy-wbshop/deploy/development/releases/4/pub/static/frontend/Magento/base/default/css/https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css): failed to open stream: No such file or directory
```

Moving the `@import` to the `layout/default.yml` fixes this problem. 