### PR TITLE
Always set cURL requests to CURLOPT_RETURNTRANSFER true

### DIFF
--- a/Helper/HttpClient.php
+++ b/Helper/HttpClient.php
@@ -49,7 +49,7 @@ class HttpClient extends AbstractHelper
     private function setCurlOptions($ch, $httpRequest, $data, $origin, $timeout)
     { 
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         if ($httpRequest == 'POST') {
             $encoded_data = $this->jsonEncoder($data);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');

--- a/Helper/HttpClient.php
+++ b/Helper/HttpClient.php
@@ -49,6 +49,7 @@ class HttpClient extends AbstractHelper
     private function setCurlOptions($ch, $httpRequest, $data, $origin, $timeout)
     { 
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         if ($httpRequest == 'POST') {
             $encoded_data = $this->jsonEncoder($data);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
@@ -57,7 +58,6 @@ class HttpClient extends AbstractHelper
             return;
         } elseif ($httpRequest == 'GET') {
             curl_setopt($ch, CURLOPT_POST, false);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             return;
         }
         return;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "trustpilot/module-reviews",
     "description": "The Trustpilot Review extension makes it simple and easy for merchants to collect reviews from their customers to power their marketing efforts, increase sales conversion, build their online reputation and draw business insights.",
     "type": "magento2-module",
-    "version": "1.0.222",
+    "version": "1.0.223",
     "license": [
       "OSL-3.0"
     ],


### PR DESCRIPTION
Although GET requests are send with this, POST requests to the API don't include curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); Therefore when a POST request is made using HttpClient to the API, the contents of the request is directly output to the screen. This is particularly problematic with the OrderSaveObserver that watches for new orders, and sends orders to the API. In the response to a payment provider, the additional output from the POST request '[]' is appended to the API response, which screws with the Javascript methods (the response from the API can't be directly JsonDecoded.