### PR TITLE
Add page size since we don't need to load full collection

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -182,6 +182,7 @@ class Data extends AbstractHelper
         $collection->addStoreFilter($this->getWebsiteOrStoreId());
         $collection->addAttributeToFilter('status', 1);
         $collection->addAttributeToFilter('visibility', array(2, 3, 4));
+        $collection->setPageSize(1);
         return $collection->getFirstItem();
     }
 
@@ -199,6 +200,7 @@ class Data extends AbstractHelper
                     $collection->setStore($storeId);
                     $collection->addAttributeToFilter('is_active', 1);
                     $collection->addAttributeToFilter('children_count', 0);
+                    $collection->setPageSize(1);
                     $category = $collection->getFirstItem();
                     $productUrl = strtok($category->getUrl(),'?').'?___store='.$storeCode;
                     return $productUrl;


### PR DESCRIPTION
Fixes issue with configuration setup in admin panel for stores having many products (e.g. 60K+ in our case).