### PR TITLE
Fix getStatusLabelForArea

### DIFF
--- a/Helper/OrderData.php
+++ b/Helper/OrderData.php
@@ -36,7 +36,8 @@ class OrderData extends AbstractHelper
             $invitation['pluginVersion'] = \Trustpilot\Reviews\Model\Config::TRUSTPILOT_PLUGIN_VERSION;
             $invitation['hook'] = $hook;
             $invitation['orderStatusId'] = $order->getState();
-            $invitation['orderStatusName'] = $order->getStatusLabel();
+            //$invitation['orderStatusName'] = $order->getStatusLabel();
+            $invitation['orderStatusName'] = $order->getStatus();
             try {
                 $invitation['templateParams'] = array((string)$this->getWebsiteId($order), (string)$this->getGroupId($order), (string)$order->getStoreId());
             } catch (\Exception $ex) {}


### PR DESCRIPTION
Added patch for magento 2.2.8 -> Argument 1 passed to Magento\Sales\Model\OrderConfig::getStatusLabelForArea() must be of the type string, null given

https://github.com/trustpilot/plugin-magento2/issues/25 hotfixed by Kevin