### PR TITLE
Update Data.php

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -127,7 +127,7 @@ class Data extends AbstractHelper
             return (int) $this->_request->getParam('website', 0);
         }
         if ($this->isAdminPage() && $this->_storeManager->getStore()->getWebsiteId()) {
-            return (int) $this->_storeManager->getStore()->getWebsiteId();
+            return (int) $this->_storeManager->getStore()->getStoreId();
         }
         if ($this->_storeManager->getStore()->getStoreId()) {
             return (int) $this->_storeManager->getStore()->getStoreId();


### PR DESCRIPTION
if you don't have a storeId 1 due migration from M1 > M2. The extension fails in the backend. This fixes it.