### PR TITLE
Add EAN for product identification options

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -276,7 +276,7 @@ class Data extends AbstractHelper
     public function getProductIdentificationOptions()
     {
         $fields = array('none', 'sku', 'id');
-        $optionalFields = array('upc', 'isbn', 'brand', 'manufacturer');
+        $optionalFields = array('upc', 'isbn', 'brand', 'manufacturer', 'ean');
         $dynamicFields = array('mpn', 'gtin');
         $attrs = array_map(function ($t) { return $t; }, $this->getAttributes());
 


### PR DESCRIPTION
When configuring the extension for product reviews. We cannot set a GTIN as our attribute code is called "ean", this change allows to select EAN as the GTIN.